### PR TITLE
Push test runner container for prod and staging

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -60,14 +60,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build, tag, and push testing image to Amazon ECR
+      - name: Build, tag, and push testing images to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.SAM_APP_ECR_REPOSITORY }}
+          ECR_REPOSITORY_STAGING: ${{ secrets.SAM_APP_ECR_REPOSITORY_STAGING }}
+          ECR_REPOSITORY_PROD: ${{ secrets.SAM_APP_ECR_REPOSITORY_PROD }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_PROD:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_PROD:$IMAGE_TAG
 
       - name: Upload lambdas to S3
         env:


### PR DESCRIPTION
To test multiple environments with test running actions. Currently just
pushes the same Docker image to both environments, but these would
likely be separate in a real situation.

Issue: PLAT-57
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
