### PR TITLE
Remove lambda signing from sam-app2 GH action

### DIFF
--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -59,8 +59,7 @@ jobs:
       - name: Upload lambdas to S3
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET }}
-          SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE"
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml


### PR DESCRIPTION
To be restored later when signing is supported by the pipeline again.

Issue: PLAT-58
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
