### PR TITLE
Trigger cloudwatch alarm on invocations

### DIFF
--- a/sam-app/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/sam-app/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -30,7 +30,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
             String output = String.format("{ \"message\": \"hello world\", \"location\": \"%s\" }", pageContents);
 
             return response
-                    .withStatusCode(500)
+                    .withStatusCode(200)
                     .withBody(output);
         } catch (IOException e) {
             return response

--- a/sam-app/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/sam-app/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,7 +11,7 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(500, result.getStatusCode().intValue());
+    assertEquals(200, result.getStatusCode().intValue());
     assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -229,7 +229,9 @@ Resources:
   HelloWorldFunctionErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      MetricName: Errors
+      Description: >
+        Test alarm to trigger if the lambda receives many requests.
+      MetricName: Invocations
       Namespace: AWS/Lambda
       Statistic: Sum
       Dimensions:
@@ -238,7 +240,7 @@ Resources:
       Period: 300
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: 1
+      Threshold: 10
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 


### PR DESCRIPTION
500 errors don't seem count as 'Errors' in lambda metrics, so we'll use
this instead to trigger an alarm.

Issue: PLAT-51
Co-authored-by: Adrian Wong <adrian.wong@digital.cabinet-office.gov.uk>
