### PR TITLE
Prevent failed run of preTrafficHook lambda

### DIFF
--- a/sam-app/preTrafficHook.js
+++ b/sam-app/preTrafficHook.js
@@ -37,7 +37,7 @@ exports.handler = (event, context, callback) => {
       //    "statusCode": 200,
       //    "body": 51
       // }
-      if(result.body.message == "hello world"){
+      if(JSON.parse(result.body).message == "hello world"){
         lambdaResult = "Succeeded";
         console.log ("Validation testing succeeded!");
       }

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -95,21 +95,35 @@ Resources:
   PreTrafficHook:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !Join
+        - "_"
+        - - "CodeDeployHook"
+          - !Ref AWS::StackName
+          - "PreTrafficHook"
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - '-'
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - /
+                          - Ref: AWS::StackId
       Handler: preTrafficHook.handler
       Policies:
         - Version: "2012-10-17"
           Statement:
-          - Effect: "Allow"
-            Action:
-              - "codedeploy:PutLifecycleEventHookExecutionStatus"
-            Resource:
-              !Sub 'arn:aws:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup:${ServerlessDeploymentApplication}/*'
+            - Effect: "Allow"
+              Action:
+                - "codedeploy:PutLifecycleEventHookExecutionStatus"
+              Resource:
+                !Sub 'arn:aws:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup:${ServerlessDeploymentApplication}/*'
         - Version: "2012-10-17"
           Statement:
-          - Effect: "Allow"
-            Action:
-              - "lambda:InvokeFunction"
-            Resource: !Ref HelloWorldFunction.Version
+            - Effect: "Allow"
+              Action:
+                - "lambda:InvokeFunction"
+              Resource: !Ref HelloWorldFunction.Version
       Runtime: nodejs14.x
       KmsKeyArn: !GetAtt HelloWorldKmsKey.Arn
       Environment:


### PR DESCRIPTION
A surprise: lambdas that are used as hooks in another lambda's
deployment preference hooks MUST have a function name that begins with
'CodeDeployHook_', hence the name for the PreTrafficHook lambda. If this
prefix isn't present, then the lambda is not granted the permissions to
write its validation status back to CodeDeploy.

Also includes a fix for the lambda, where an extra JSON parse needed to
be performed.

Issue: PLAT-51
Co-authored-by: Adrian Wong <adrian.wong@digital.cabinet-office.gov.uk>
