### PR TITLE
Enable access to cross-account params from prod

### DIFF
--- a/cross-account/template.yaml
+++ b/cross-account/template.yaml
@@ -30,7 +30,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: "arn:aws:iam::223594937353:root"
+              AWS:
+                - "arn:aws:iam::223594937353:root"
+                - "arn:aws:iam::092449966640:root"
             Action:
               - 'sts:AssumeRole'
       Policies:


### PR DESCRIPTION
The production account request access to the cross-account Parameter
Store to deploy the demo SAM app successfully.

Issue: Tech debt