### PR TITLE
Include OpenAPI spec in sam-app Serverless::Api

### DIFF
--- a/sam-app/HelloWorldFunction2/src/main/java/helloworld2/App2.java
+++ b/sam-app/HelloWorldFunction2/src/main/java/helloworld2/App2.java
@@ -1,4 +1,4 @@
-package helloworld;
+package helloworld2;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/sam-app/HelloWorldFunction2/src/test/java/helloworld/App2Test.java
+++ b/sam-app/HelloWorldFunction2/src/test/java/helloworld/App2Test.java
@@ -1,4 +1,4 @@
-package helloworld;
+package helloworld2;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import static org.junit.Assert.assertEquals;

--- a/sam-app/openapi-spec.yaml
+++ b/sam-app/openapi-spec.yaml
@@ -1,0 +1,27 @@
+---
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: "demo-sam-app"
+basePath: "/Prod"
+schemes:
+- "https"
+paths:
+  /hello:
+    get:
+      responses: {}
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloWorldFunction.Arn}:HelloWorldFunction/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws_proxy"
+  /hello2:
+    get:
+      responses: {}
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloWorldFunction2.Arn}/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws_proxy"

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -58,7 +58,7 @@ Resources:
   HelloWorldRestApi:
     Type: AWS::Serverless::Api
     Properties:
-      StageName: prod
+      StageName: Prod
       AccessLogSetting:
         Format: "$context.requestId $context.httpMethod $context.path"
         DestinationArn: !GetAtt APIGatewayAccessLogGroup.Arn


### PR DESCRIPTION
Required to demonstrate how cloudformation includes can be used and be
valid with the pipeline. Also provides a useful test case.

A surprising thing: When the lambda ARNs have to be provided in the
OpenAPI spec 'uri' properties, for HelloWorldFunction, an additional
`:HelloWorldFunction` needed to be put at the end of the ARN in order
for the function to be executable by API Gateway. This was not required
for HelloWorldFunction2. A theory is that the `:HelloWorldFunction` is
the AutoPublishAlias value.

Issue: PLAT-87
Co-authored-by: Mauro Vilasi <mauro.vilasi@digital.cabinet-office.gov.uk>
