### PR TITLE
Add PermissionsBoundary to demo apps

### DIFF
--- a/node/template.yaml
+++ b/node/template.yaml
@@ -16,7 +16,20 @@ Parameters:
       run.
     Type: String
 
+  PermissionsBoundary:
+    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
+    Type: String
+    Default: "none"
+
+Conditions:
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+
 Mappings:
+  # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416
@@ -161,6 +174,10 @@ Resources:
                 Action:
                   - logs:CreateLogGroup
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-TaskExecutionRole"

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -11,6 +11,11 @@ Parameters:
     Description: Asserts that lambdas are signed when deployed.
     Default: "none"
 
+  PermissionsBoundary:
+    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
+    Type: String
+    Default: "none"
+
   Bar:
     Type: String
     Default: "none"
@@ -23,12 +28,22 @@ Conditions:
           - !Ref CodeSigningConfigArn
           - "none"
 
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
     CodeSigningConfigArn: !If
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     Timeout: 20
 

--- a/sam-app2/template.yaml
+++ b/sam-app2/template.yaml
@@ -5,10 +5,27 @@ Description: >
 
   Sample SAM Template for sam-app2
 
+Parameters:
+  PermissionsBoundary:
+    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
+    Type: String
+    Default: "none"
+
+Conditions:
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
     Timeout: 20
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
 
 Resources:
   HelloWorldFunction:


### PR DESCRIPTION
The pipelines now impose an IAM permissions boundary on applications
that it deploys and so the example applications need to be updated
to take the PermissionsBoundary ARN as a parameter and apply it
whenever they create a role (or when SAM does it on their behalf).

Issue: PLAT-37