### PR TITLE
Add CodeDeployServiceRole with permissions boundry

### DIFF
--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -133,6 +133,7 @@ Resources:
           - !Ref HelloWorldFunctionTooManyRequestsAlarm
         Hooks:
           PreTraffic: !Ref PreTrafficHook
+        Role: !GetAtt CodeDeployServiceRole.Arn
       Tags:
         BillingOrganization: GDS
         BillingProgramme: One Login for Government
@@ -141,6 +142,22 @@ Resources:
         Service: backend
         Name: HelloWorldFunction
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary: !Ref PermissionsBoundary
 
   HelloWorldFunction2:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction


### PR DESCRIPTION
Required because the auto-generated role doesn't have the permissions
boundary set, so it cannot be created or modified.

Issue: PLAT-88
Co-authored-by: Adrian Wong <adrian.wong@digital.cabinet-office.gov.uk>
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
