### PR TITLE
Add provenance metadata during `sam package`

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -76,7 +76,15 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET }}
           SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE"
+        run: >
+          sam package
+            --s3-bucket="$ARTIFACT_BUCKET"
+            --output-template-file=cf-template.yaml
+            --signing-profiles
+              HelloWorldFunction="$SIGNING_PROFILE"
+              HelloWorldFunction2="$SIGNING_PROFILE"
+              PreTrafficHook="$SIGNING_PROFILE"
+            --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -59,7 +59,15 @@ jobs:
       - name: Upload lambdas to S3
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
+          SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
+        run: >
+          sam package
+            --s3-bucket="$ARTIFACT_BUCKET"
+            --output-template-file=cf-template.yaml
+            --signing-profiles
+              HelloWorldFunction="$SIGNING_PROFILE"
+            --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
+
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml


### PR DESCRIPTION
Required to later be used for lambda audit logging, allowing the
provenance of a lambda deployment to be tracable.

Issue: PLAT-47
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
