### PR TITLE
Join lines in GitHub actions command

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -76,15 +76,7 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET }}
           SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: >
-          sam package
-            --s3-bucket="$ARTIFACT_BUCKET"
-            --output-template-file=cf-template.yaml
-            --signing-profiles
-              HelloWorldFunction="$SIGNING_PROFILE"
-              HelloWorldFunction2="$SIGNING_PROFILE"
-              PreTrafficHook="$SIGNING_PROFILE"
-            --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE" --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -60,13 +60,7 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET }}
           SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: >
-          sam package
-            --s3-bucket="$ARTIFACT_BUCKET"
-            --output-template-file=cf-template.yaml
-            --signing-profiles
-              HelloWorldFunction="$SIGNING_PROFILE"
-            --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
 
 
       - name: Zip the cloudformation template


### PR DESCRIPTION
Required because GitHub actions does not seem to tolarate the scalar
style multi-line strings. Just the first line of this command is
executed instead of joining it together with spaces, causing an error.

Issue: PLAT-47
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
