### PR TITLE
Add provenance metadata to signed artifacts

### DIFF
--- a/.github/scripts/write-lambda-provenance.sh
+++ b/.github/scripts/write-lambda-provenance.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yq '.. | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "Repository=$GITHUB_REPOSITORY,CommitSHA=$GITHUB_SHA"

--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -76,7 +76,12 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET }}
           SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE" --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE"
+
+      - name: Write lambda provenance
+        run: '.github/scripts/write-lambda-provenance.sh'
+        shell: bash
+
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -60,8 +60,11 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET }}
           SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
-        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" --metadata repo=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE"
 
+      - name: Write lambda provenance
+        run: '.github/scripts/write-lambda-provenance.sh'
+        shell: bash
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml


### PR DESCRIPTION
Required inspecting the compiled template for the artifact locations,
since using `sam package --metadata ...` only writes metadata to
unsigned artifacts :(

Issue: PLAT-5
Co-authored-by: Mike Winter <mike.winter@digital.cabinet-office.gov.uk>
