### PR TITLE
Fix path references to workflow script

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -79,9 +79,8 @@ jobs:
         run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE"
 
       - name: Write lambda provenance
-        run: '.github/scripts/write-lambda-provenance.sh'
+        run: '../.github/scripts/write-lambda-provenance.sh'
         shell: bash
-
 
       - name: Zip the cloudformation template
         run: zip template.zip cf-template.yaml

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -63,7 +63,7 @@ jobs:
         run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE"
 
       - name: Write lambda provenance
-        run: '.github/scripts/write-lambda-provenance.sh'
+        run: '../.github/scripts/write-lambda-provenance.sh'
         shell: bash
 
       - name: Zip the cloudformation template


### PR DESCRIPTION
The working directory within each workflow has been set to the
respective application directory. The workflow script is in a
sibling directory within the repository, so references must go
via the parent directory.

Issue: PLAT-5
Co-authored-by: Joshua Taylor <joshua.taylor@digital.cabinet-office.gov.uk>