### PR TITLE
Enable X-Ray tracing on demo-app lambdas

### DIFF
--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -104,6 +104,7 @@ Resources:
         - x86_64
       MemorySize: 512
       KmsKeyArn: !GetAtt HelloWorldKmsKey.Arn
+      Tracing: Active
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
@@ -170,6 +171,7 @@ Resources:
         - x86_64
       MemorySize: 512
       KmsKeyArn: !GetAtt HelloWorldKmsKey.Arn
+      Tracing: PassThrough
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE


### PR DESCRIPTION
Required to test whether X-Ray operations get through the permissions
boundary.

Issue: PLAT-97
Co-authored-by: Jowita Podolak <jowita.podolak@digital.cabinet-office.gov.uk>
Co-authored-by: Cristhian Da Silva Fernandez <cristhian.dasilvafernandez@digital.cabinet-office.gov.uk>
