### PR TITLE
Fix for lambda provenance script

### DIFF
--- a/.github/scripts/write-lambda-provenance.sh
+++ b/.github/scripts/write-lambda-provenance.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-yq '.. | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
+yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
     | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"


### PR DESCRIPTION
In some circumstances the script would fail when trying to match
the AWS::Serverless::Lambda value on the .Type clause with an
index type error.

Issue: PLAT-100