### PR TITLE
Enable code signing support for sam-app2

### DIFF
--- a/sam-app2/template.yaml
+++ b/sam-app2/template.yaml
@@ -6,12 +6,23 @@ Description: >
   Sample SAM Template for sam-app2
 
 Parameters:
+  CodeSigningConfigArn:
+    Type: String
+    Description: Asserts that lambdas are signed when deployed.
+    Default: "none"
+
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
 
 Conditions:
+  UseCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
+
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -22,6 +33,10 @@ Conditions:
 Globals:
   Function:
     Timeout: 20
+    CodeSigningConfigArn: !If
+      - UseCodeSigning
+      - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary


### PR DESCRIPTION
Code signing is now required for all Lambdas deployed through the SAM
deploy pipelines.

Issue: PLAT-72
Co-authored-by: Cristhian Da Silva <cristhian.dasilvafernandez@digital.cabinet-office.gov.uk>