### PR TITLE
Rename secrets as part of move to build account

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.SAM_APP_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.SAM_APP_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: SAM validate
@@ -63,19 +63,19 @@ jobs:
       - name: Build, tag, and push testing images to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_BUILD: ${{ secrets.SAM_APP_ECR_REPOSITORY_BUILD }}
           ECR_REPOSITORY_STAGING: ${{ secrets.SAM_APP_ECR_REPOSITORY_STAGING }}
-          ECR_REPOSITORY_PROD: ${{ secrets.SAM_APP_ECR_REPOSITORY_PROD }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_PROD:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_PROD:$IMAGE_TAG
 
       - name: Upload lambdas to S3
         env:
-          ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET }}
-          SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
+          ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
+          SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE_NAME }}
         run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles HelloWorldFunction="$SIGNING_PROFILE" HelloWorldFunction2="$SIGNING_PROFILE" PreTrafficHook="$SIGNING_PROFILE"
 
       - name: Write lambda provenance
@@ -87,5 +87,5 @@ jobs:
 
       - name: Upload zipped cloudformation artifact to S3
         env:
-          ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET }}
+          ARTIFACT_BUCKET: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
         run: aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"

--- a/.github/workflows/sam-app-pre-merge-checks.yml
+++ b/.github/workflows/sam-app-pre-merge-checks.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.SAM_APP_VALIDATE_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.SAM_APP_VALIDATE_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Cache Gradle packages


### PR DESCRIPTION
We adopted more descriptive secret names some time after creating the
original demo app, but didn't make these names consistent. Some values
need to change as part of starting deployment in the build account, so
this presents an opportunity to revise all names.

Issue: PLAT-90