### PR TITLE
Get SAM project directory from current directory

### DIFF
--- a/scripts/deployment_helper.sh
+++ b/scripts/deployment_helper.sh
@@ -12,9 +12,10 @@ function login() {
 }
 
 function build() {
+  local project_dir=$(git rev-parse --show-toplevel)
   local app_to_deploy="$1"
   echo "Going into $app_to_deploy"
-  cd "$PROJECT_DIR/$app_to_deploy"
+  cd "$project_dir/$app_to_deploy"
   echo "Building sam app"
   sam build
 }


### PR DESCRIPTION
Required since when the helper file is sourced and a script moves to
another directory, then the incorrect directory may be used here.

Issue: PLAT-104
Co-authored-by: Cristhian Da Silva Fernandez <cristhian.dasilvafernandez@digital.cabinet-office.gov.uk>
