### PR TITLE
Add CloudFront to sam-app2

### DIFF
--- a/sam-app2/template.yaml
+++ b/sam-app2/template.yaml
@@ -44,6 +44,7 @@ Globals:
 Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    #checkov:skip=CKV_AWS_116
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
@@ -188,7 +189,20 @@ Resources:
   HelloWafLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: aws-waf-logs-hello-waf
+      LogGroupName:
+        Fn::Join:
+          - '-'
+          - - aws-waf-logs-
+            - Ref: AWS::StackName
+            - Fn::Select:
+                - 4
+                - Fn::Split:
+                    - '-'
+                    - Fn::Select:
+                        - 2
+                        - Fn::Split:
+                            - /
+                            - Ref: AWS::StackId
       RetentionInDays: 1
       KmsKeyId: !GetAtt HelloWorldKmsKey.Arn
       Tags:
@@ -206,6 +220,101 @@ Resources:
         - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${HelloWafLogGroup}"
       ResourceArn: !GetAtt HelloWaf.Arn
 
+  CloudFrontAccessLogBucket:
+    Type: AWS::S3::Bucket
+    #checkov:skip=CKV_AWS_18
+    Properties:
+      BucketName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - "cloudfrontaccesslog"
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - '-'
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - /
+                          - Ref: AWS::StackId
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: CheckovRulesToSkip
+          Value: CKV_AWS_18
+
+  CloudFrontOriginBucket:
+    Type: AWS::S3::Bucket
+    #checkov:skip=CKV_AWS_18
+    Properties:
+      BucketName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - "cloudfrontorigin"
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - '-'
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - /
+                          - Ref: AWS::StackId
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: CheckovRulesToSkip
+          Value: CKV_AWS_18
+
+  CloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: "woah this is an identity"
+
+  HelloCloudFront:
+    Type: AWS::CloudFront::Distribution
+    #checkov:skip=CKV_AWS_68
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Logging:
+          Bucket: !GetAtt CloudFrontAccessLogBucket.DomainName
+        ViewerCertificate:
+          MinimumProtocolVersion: TLSv1.2_2018
+          CloudFrontDefaultCertificate: true
+        DefaultCacheBehavior:
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6  # AWS Managed Cache Policy
+          TargetOriginId: CloudFrontOriginBucket
+          ViewerProtocolPolicy: https-only
+        Origins:
+          - DomainName: !GetAtt CloudFrontOriginBucket.DomainName
+            Id: CloudFrontOriginBucket
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+      Tags:
+        - Key: CheckovRulesToSkip
+          Value: CKV_AWS_68
+
+      # TODO: Add tags
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
Required to show how CloudFront can be configured for use with the
secure pipelines.

The configuration here is naive, based on a few assumptions. It may be
updated later to reflect how the teams use CloudFront.

CKV_AWS_68 needed to be skipped since CloudFront distributions require
all associated WAFs to be global. All global WAFs must be created in the
us-east-1 region. Our pipeline currenly only allow eu-west-2. So some
work needs to be done to remove this skip.

Any log groups used by WAF must be prefixed with `aws-waf-logs-*`, hence
the special prefix on HelloWafLogGroup.

Issue: PLAT-104
Co-authored-by: Cristhian Da Silva Fernandez <cristhian.dasilvafernandez@digital.cabinet-office.gov.uk>
