### PR TITLE
Add public Route53 hosted zone

### DIFF
--- a/route53/README.md
+++ b/route53/README.md
@@ -1,0 +1,7 @@
+# Route53
+
+This stack defines a public hosted zone for use within the demo app. The zone
+is `platform.sandpit.account.gov.uk`. The zone delegation is configured in the
+[di-infrastructure](https://github.com/alphagov/di-infrastructure) repository.
+It is important that the zone is not deleted, otherwise the name servers will
+be changed and the zone delegation will fail.

--- a/route53/template.yaml
+++ b/route53/template.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Public Route53 Zone
+
+Resources:
+  PlatformHostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: "Retain"
+    Properties:
+      Name: "platform.sandpit.account.gov.uk"
+      HostedZoneConfig:
+        Comment: "Delegated via alphagov/di-infrastructure repo"
+      HostedZoneTags:
+        - Key: "Product"
+          Value: "GOV.UK Sign In"
+        - Key: "System"
+          Value: "Dev Platform"
+        - Key: "Environment"
+          Value: "Demo"
+        - Key: "Name"
+          Value: "HostedZone"
+        - Key: "Source"
+          Value: "alphagov/di-devplatform-demo-sam-app/route53/template.yaml"
+
+Outputs:
+  PlatformHostedZonedId:
+    Value: !Ref PlatformHostedZone
+    Export:
+      Name: PlatformHostedZone


### PR DESCRIPTION
The template defines a public hosted zone and the associated nameservers
have been used to register the subdomain via the alphagov/di-infrastructure
repo.

Issue: PLAT-112