### PR TITLE
PLAT-203 Removed bucket-notifications to CSLS

### DIFF
--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -357,12 +357,13 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      NotificationConfiguration:
-        QueueConfigurations:
-          - Event: "s3:ObjectCreated:*"
-            Queue: "arn:aws:sqs:eu-west-2:885513274347:cyber-security-s3-to-splunk-prodpython"
-          - Event: "s3:ObjectRestore:*"
-            Queue: "arn:aws:sqs:eu-west-2:885513274347:cyber-security-s3-to-splunk-prodpython" 
+      # This cannot be implemented as this, as the target account needs permissions before the bucket name is know, but it permissions based on the bucketName.
+      # NotificationConfiguration:
+      #   QueueConfigurations:
+      #     - Event: "s3:ObjectCreated:*"
+      #       Queue: "arn:aws:sqs:eu-west-2:885513274347:cyber-security-s3-to-splunk-prodpython"
+      #     - Event: "s3:ObjectRestore:*"
+      #       Queue: "arn:aws:sqs:eu-west-2:885513274347:cyber-security-s3-to-splunk-prodpython" 
       Tags:
         - Key: Product
           Value: GOV.UK Sign In


### PR DESCRIPTION
Reverted bucket notifications due to a tight-coupling of AWS resources cross-account.