### PR TITLE
PLAT 540-sam demo app cfn lint update

### DIFF
--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-pip3.9-
 
       - name: Install linters
-        run: pip install 'cfn-lint~=0.72.2' 'poetry~=0.12.17' 'checkov~=2.2.130'
+        run: pip install 'cfn-lint~=0.72.3' 'poetry~=0.12.17' 'checkov~=2.2.130'
 
       - name: Lint templates
         run: '.github/scripts/lint.sh'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         args: ['--verbose']
         verbose: true  # print warnings
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.58.1
+    rev: v0.72.3
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$


### PR DESCRIPTION
Cfn Lint needs to be updated from cfn-lint~=0.65.1 to  [0.72.3](https://github.com/aws-cloudformation/cfn-lint/releases/tag/v0.72.3) in the sam demo repo

https://govukverify.atlassian.net/browse/PLAT-540