### PR TITLE
Plat 478 - sam app deployment fix

### DIFF
--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -47,7 +47,7 @@ Mappings:
       DomainName: "staging.demoapp.platform.sandpit.account.gov.uk"
     integration:
       DomainName: "integration.demoapp.platform.sandpit.account.gov.uk"
-    prod:
+    production:
       DomainName: "prod.demoapp.platform.sandpit.account.gov.uk"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst


### PR DESCRIPTION
Changes in this PR:

1. Ported version control checkov check CKV_AWS_21 fix from other demo apps, so it does not need to be skipped
2. Typo on mapping for production API Domain name