### PR TITLE
PLAT-971 Updated workflows to use beta version of upload-action for testing

### DIFF
--- a/.github/workflows/aws-integration-test-post-merge-actions.yaml
+++ b/.github/workflows/aws-integration-test-post-merge-actions.yaml
@@ -99,7 +99,7 @@ jobs:
         run: ./build.sh
 
       - name: Deploy
-        uses: alphagov/di-devplatform-upload-action@v2
+        uses: alphagov/di-devplatform-upload-action@v3.1-beta
         with:
           artifact-bucket-name: ${{ secrets.AWS_INTEGRATION_TEST_ARTIFACT_SOURCE_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -83,7 +83,7 @@ jobs:
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3-beta
+        uses: alphagov/di-devplatform-upload-action@v3.1-beta
         with:
             artifact-bucket-name: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -59,7 +59,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3-beta
+        uses: alphagov/di-devplatform-upload-action@v3.1-beta
         with:
           artifact-bucket-name: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
Updated the workflows to point to @v3.1-beta of the upload-action GHA.
![image](https://user-images.githubusercontent.com/104910888/229776505-2933650f-ac2a-4381-8f50-44384d26de16.png)
