### PR TITLE
PLAT-1442 - Reference .aws-sam/build dir in the upload action

### DIFF
--- a/.github/workflows/sam-app-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app-deploy-using-environment-secrets.yml
@@ -81,4 +81,4 @@ jobs:
         with:
             artifact-bucket-name: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-            working-directory: ./sam-app
+            working-directory: ./sam-app/.aws-sam/build

--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -87,4 +87,4 @@ jobs:
         with:
             artifact-bucket-name: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-            working-directory: ./sam-app
+            working-directory: ./sam-app/.aws-sam/build

--- a/.github/workflows/sam-app2-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app2-deploy-using-environment-secrets.yml
@@ -81,4 +81,4 @@ jobs:
         with:
           artifact-bucket-name: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: ./sam-app2
+          working-directory: ./sam-app2/.aws-sam/build

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           artifact-bucket-name: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: ./sam-app2
+          working-directory: ./sam-app2/.aws-sam/build


### PR DESCRIPTION
Ref .aws-sam/build dir in the upload action
sam build downloads, installs, and organizes dependencies in the .aws-sam/build directory.
The CoreUri paths set in sam-app* function templates reference source on a relative path from the current working directory.
Set working-directory to .aws-sam/build so that these compiled code and dependencies are packaged into the signed lambda.zip artifact.

Issue: [PLAT-1442](https://govukverify.atlassian.net/browse/PLAT-1442)
Co-authored-by:

[PLAT-1442]: https://govukverify.atlassian.net/browse/PLAT-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ