### PR TITLE
enabled transparency logging

### DIFF
--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -617,7 +617,7 @@ Resources:
           HostedZoneId:
             Fn::ImportValue: PlatformHostedZone
       ValidationMethod: DNS
-      CertificateTransparencyLoggingPreference: DISABLED
+      CertificateTransparencyLoggingPreference: ENABLED
       Tags:
         - Key: Name
           Value: ApiGatewayCertificate
@@ -645,7 +645,7 @@ Outputs:
   HelloWorldApiDomain:
     Description: "API Gateway domain"
     Value: !Sub
-      - "${AWS::StackName}.${DomainName}"
+      - "https://${AWS::StackName}.${DomainName}/hello/"
       - DomainName: !FindInMap
           - APIDomainNames
           - !Ref Environment


### PR DESCRIPTION
## Description
- Domains are working but endpoint has to be added to the link for it to work

:white_check_mark:  https://PLAT-479-test.build.demoapp.platform.sandpit.account.gov.uk/hello/

:x: PLAT-479-test.build.demoapp.platform.sandpit.account.gov.uk

- Fixed stack Output to add the endpoint to link

- Enabled CertificateTransparencyLoggingPreference to avoid Google Chrome certificate warning

### Ticket number
[PLAT-479]
## Checklist

- [x] I have tested this and added output to Jira
![Screenshot 2023-06-22 at 12 35 52](https://github.com/alphagov/di-devplatform-demo-sam-app/assets/93530090/db91fd83-c312-427e-8444-ac4b7883957f)

- [x] Delete any new stacks created for this ticket


[PLAT-479]: https://govukverify.atlassian.net/browse/PLAT-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ