### PR TITLE
[PLAT-1873] Fix dependency installation for integration tests

### DIFF
--- a/aws-integration-test/aws-integration/Dockerfile
+++ b/aws-integration-test/aws-integration/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian:stable-slim
-RUN apt-get update && apt-get install -y python3 python3-pip awscli
-RUN pip install poetry
+RUN apt-get update && apt-get install -y python3 python3-pip awscli python3-poetry
 WORKDIR /tests/
 COPY pyproject.toml poetry.lock ./
 RUN poetry install


### PR DESCRIPTION
## Description
- Changed installation method for Poetry
- This fixes error related to the introduction of [PEP 668](https://peps.python.org/pep-0668/?ref=itsfoss.com)
### Ticket number
[PLAT-1873]
## Checklist

- [x] I have tested this and added output to Jira
<img width="545" alt="Screenshot 2023-07-05 at 13 57 01" src="https://github.com/alphagov/di-devplatform-demo-sam-app/assets/93530090/e859035f-1057-49d8-bd0d-5a10db2bbc97">

[PLAT-1873]: https://govukverify.atlassian.net/browse/PLAT-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ