### PR TITLE
PLAT-2519 - References to di-domains repo updated 

### DIFF
--- a/platform-hosted-zone/README.md
+++ b/platform-hosted-zone/README.md
@@ -33,6 +33,6 @@ The list of resources this template creates:
 The list of outputs this template exposes:
 | Output           | Description   |
 |------------------|---------------|
-| PlatformHostedZoneId | 
+| PlatformHostedZoneId | |
 
-[1]: https://github.com/alphagov/di-domains/tree/main 
+[1]: https://github.com/govuk-one-login/domains/tree/main

--- a/platform-hosted-zone/template.yaml
+++ b/platform-hosted-zone/template.yaml
@@ -35,7 +35,7 @@ Resources:
     Properties:
       Name: !FindInMap ["EnvironmentSettings", !Ref Environment, "DomainName"]
       HostedZoneConfig:
-        Comment: Delegated via alphagov/di-domains repo
+        Comment: Delegated via govuk-one-login/domains repo
       HostedZoneTags:
         - Key: Product
           Value: GOV.UK Sign In


### PR DESCRIPTION
## Description

Inline with GitHub Org migration. New location for repo would be govuk-one-login/domains

### Ticket number
[PLAT-2519]
## Checklist

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-2519]: https://govukverify.atlassian.net/browse/PLAT-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ