### PR TITLE
PLAT-3322 - Escape Hatch: skip canary deployments when needed

### DIFF
--- a/node/template.yaml
+++ b/node/template.yaml
@@ -23,9 +23,10 @@ Parameters:
   DeploymentStrategy:
     Description: "Predefined deployment configuration for ECS application"
     Type: String
-    Default: "CodeDeployDefault.ECSCanary10Percent5Minutes"
+    Default: "None"
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
     AllowedValues:
+      - None
       - CodeDeployDefault.ECSCanary10Percent5Minutes
       - CodeDeployDefault.ECSCanary10Percent15Minutes
       - CodeDeployDefault.ECSAllAtOnce
@@ -52,6 +53,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+
+  UseECSCanaryDeploymentStack:
+    Fn::Not:
+      - Fn::Equals:
+        - !Ref DeploymentStrategy
+        - None
 
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
@@ -97,7 +104,10 @@ Resources:
       Cluster: !Ref FargateCluster
       LaunchType: FARGATE
       DeploymentController:
-        Type: CODE_DEPLOY
+        Type: !If
+          - UseECSCanaryDeploymentStack
+          - CODE_DEPLOY
+          - ECS
       LoadBalancers:
         - ContainerName: !Sub "${AWS::StackName}-node-server"
           ContainerPort: 8000
@@ -112,6 +122,10 @@ Resources:
             - Fn::ImportValue:
                 !Sub "${VpcStackName}-PrivateSubnetIdB"
       PropagateTags: SERVICE
+      TaskDefinition: !If
+        - UseECSCanaryDeploymentStack
+        - !Ref AWS::NoValue
+        - !Ref TaskDefinition
       # TaskDefinition: !Ref TaskDefinition
       Tags:
         - Key: Name
@@ -228,7 +242,7 @@ Resources:
       Cpu: 256
       Memory: 512
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
-      Family: server
+      Family: !Sub "${AWS::StackName}-server"
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -456,6 +470,7 @@ Resources:
 
   ECSCanaryDeploymentStack:
     Type: AWS::CloudFormation::Stack
+    Condition: UseECSCanaryDeploymentStack
     Properties:
       TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml"
       Parameters:


### PR DESCRIPTION
## Description

Bump upload-action-ecr custom GHA to 1.2.0, includes the skipcanary metadata required for the functionality
DeploymentStrategy set as a parameter, defaults to CodeDeployDefault.ECSCanary10Percent5Minutes

### Ticket number
[PLAT-3322]
## Checklist

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-3322]: https://govukverify.atlassian.net/browse/PLAT-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ