### PR TITLE
PLAT-3416: updating java version for sonarcube

### DIFF
--- a/.github/workflows/sam-app-pre-merge-checks.yml
+++ b/.github/workflows/sam-app-pre-merge-checks.yml
@@ -68,6 +68,13 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
+      - name: Set up JDK 17 for Sonar
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: gradle
+
       - name: Sonar scan
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:


### PR DESCRIPTION
## Description

Sonarcube scanning needs `Java version 17 `or newer. The current Gradle programs are using `Java version 11`

### Ticket number
[PLAT-3416]
## Checklist

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-3416]: https://govukverify.atlassian.net/browse/PLAT-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ