### PR TITLE
PLAT-3824 Disable plugin for caching docker image layers

### DIFF
--- a/.github/workflows/aws-integration-test-post-merge-actions.yaml
+++ b/.github/workflows/aws-integration-test-post-merge-actions.yaml
@@ -43,9 +43,10 @@ jobs:
         with:
           cosign-release: 'v1.9.0'
 
-      - name: Cache Image Layers
-        uses: jpribyl/action-docker-layer-caching@v0.1.1
-        continue-on-error: true
+      #  Disabling this caching mechanism to see why its filling up disk
+      # - name: Cache Image Layers
+      #   uses: jpribyl/action-docker-layer-caching@v0.1.1
+      #   continue-on-error: true
 
       - name: Disk Space Usage
         run: |


### PR DESCRIPTION
## Description
Disabling the Docker image caching plugin to see why its filling the disk up on the Github action runner


### Ticket number
[PLAT-3824]

## Checklist

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-3824]: https://govukverify.atlassian.net/browse/PLAT-3824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ