### PR TITLE
Bug-fix: Updating docker image

### DIFF
--- a/node/tests/Dockerfile
+++ b/node/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
 RUN yum install -y awscli
-RUN yum install httpd-tools
+RUN yum install -y httpd-tools
 
 COPY run-tests.sh ./


### PR DESCRIPTION
## Description

The below line is missing the `-y` flag:
`RUN yum install httpd-tools` 

<img width="1225" alt="Screenshot 2024-03-06 at 15 03 46" src="https://github.com/govuk-one-login/devplatform-demo-sam-app/assets/117449945/e019dc49-0b70-4a59-a4eb-c3014670aeac">

https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/runs/8174141737

### Ticket number
[PLAT-XXX]
## Checklist

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by