### PR TITLE
Plat 3666: Adds anomaly detection alarms for canary deployments

### DIFF
--- a/sam-app/README.md
+++ b/sam-app/README.md
@@ -9,6 +9,8 @@ This project contains source code and supporting files for a serverless applicat
 
 The application uses several AWS resources, including Lambda functions and an API Gateway API. These resources are defined in the `template.yaml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code.
 
+This application also includes an example of a backend Lambda canary deployment solution, for more information and an implamentaion guide please visit: [Lambda - Canary Deployment Migration Guidance](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3823436177/Lambda+-+Canary+Deployment+Migration+Guidance)
+
 ## Deploy the sample application
 
 The Serverless Application Model Command Line Interface (SAM CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -30,6 +30,11 @@ Parameters:
     Description: "The name of the environment to deploy to"
     Type: "String"
 
+  NotificationTopicArn:
+    Description: "The ARN of the SNS topic used for notifications"
+    Type: "String"
+    Default: "none"
+
 Conditions:
   IsNonDevEnvironment:
     Fn::Not:
@@ -55,6 +60,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+
+  UseAlarmActions:
+    Fn::Not:
+      - Fn::Equals:
+        - !Ref NotificationTopicArn
+        - "none"
 
 Mappings:
   APIDomainNames:
@@ -226,8 +237,11 @@ Resources:
         Alarms:
           - !Ref HelloWorldFunctionTooManyRequestsAlarm
           - !Ref HelloWorldLambdaErrors
-          - !Ref HelloWorldLambda4XXAlarm
-          - !Ref HelloWorldLambda5XXAlarm
+          # Anomaly alarms need to be active in an account prior to being added as a deployment alarm.
+          # Otherwise there is a risk of false positives
+          - !Ref HelloWorldFunctionInvocationAnomalyAlarm
+          - !Ref HelloWorldLambda4XXAnomalyAlarm
+          - !Ref HelloWorldLambdaErrorAnomalyAlarm
         Hooks:
           PreTraffic: !Ref PreTrafficHook
           PostTraffic: !Ref PostTrafficHook
@@ -637,6 +651,138 @@ Resources:
         - Key: Source
           Value: govuk-one-login/devplatform-demo-sam-app/sam-app/template.yaml
 
+  #
+  # Anomaly detection
+  #
+
+  HelloWorldLambdaErrorAnomalyDetector:
+    Type: AWS::CloudWatch::AnomalyDetector
+    Properties:
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Stat: Sum
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref HelloWorldFunction
+
+  HelloWorldLambdaInvocationsAnomalyDetector:
+    Type: AWS::CloudWatch::AnomalyDetector
+    Properties:
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Stat: Sum
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref HelloWorldFunction
+
+  HelloWorldLambda4XXErrorAnomalyDetector:
+    Type: AWS::CloudWatch::AnomalyDetector
+    Properties:
+      MetricName: 4XXError
+      Namespace: AWS/ApiGateway
+      Stat: Sum
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref HelloWorldFunction
+
+  HelloWorldLambdaErrorAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-HelloWorldLambdaErrorsAnomalies"
+      AlarmDescription: >
+        Alarm to detect Lambda error anomalies
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Ref NotificationTopicArn
+        - []
+      ComparisonOperator: GreaterThanUpperThreshold
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      ThresholdMetricId: ad1
+      TreatMissingData: notBreaching
+      Metrics:
+      - Id: ad1
+        ReturnData: True
+        Expression: ANOMALY_DETECTION_BAND(m1, 2)
+      - Id: m1
+        ReturnData: True
+        MetricStat:
+          Metric:
+            Namespace: AWS/Lambda
+            MetricName: Errors
+            Dimensions:
+              - Name: FunctionName
+                Value: !Ref HelloWorldFunction
+          Period: 60
+          Stat: Sum
+
+
+  HelloWorldLambda4XXAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-HelloWorldLambda4XXAnomalyAlarm"
+      AlarmDescription: >
+        Test alarm to trigger if a 4XX status code is received.
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Ref NotificationTopicArn
+        - []
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      ComparisonOperator: GreaterThanUpperThreshold
+      ThresholdMetricId: ad2
+      TreatMissingData: notBreaching
+      Metrics:
+      - Id: ad2
+        ReturnData: True
+        Expression: ANOMALY_DETECTION_BAND(m2, 2)
+      - Id: m2
+        ReturnData: True
+        MetricStat:
+          Metric:
+            Namespace: AWS/ApiGateway
+            MetricName: 4XXError
+            Dimensions:
+              - Name: FunctionName
+                Value: !Ref HelloWorldFunction
+          Period: 60
+          Stat: Sum
+
+  HelloWorldFunctionInvocationAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-HelloWorldFunctionInvocationAnomalyAlarm"
+      AlarmDescription: >
+        Test alarm to trigger if the lambda receives many requests.
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Ref NotificationTopicArn
+        - []
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      ComparisonOperator: GreaterThanUpperThreshold
+      TreatMissingData: notBreaching
+      ThresholdMetricId: ad3
+      Metrics:
+      - Id: ad3
+        ReturnData: True
+        Expression: ANOMALY_DETECTION_BAND(m3, 2)
+      - Id: m3
+        ReturnData: True
+        MetricStat:
+          Metric:
+            Namespace: AWS/Lambda
+            MetricName: Invocations
+            Dimensions:
+              - Name: FunctionName
+                Value: !Ref HelloWorldFunction
+          Period: 300
+          Stat: Sum
+
+  #
+  # Cloudwatch Alarms
+  #
+
   HelloWorldFunctionTooManyRequestsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -713,6 +859,9 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
+  #
+  # Certificates & Certificate Record
+  #
   HelloWorldCertificateRecord:
     Type: AWS::Route53::RecordSet
     Condition: IsNonDevEnvironment
@@ -730,9 +879,6 @@ Resources:
         DNSName: !GetAtt HelloWorldRestAPIDomainName.RegionalDomainName
         HostedZoneId: !GetAtt HelloWorldRestAPIDomainName.RegionalHostedZoneId
 
-  #
-  # Certificates
-  #
   ApiGatewayCertificate:
     Type: AWS::CertificateManager::Certificate
     Condition: IsNonDevEnvironment


### PR DESCRIPTION
## Description
Created anomaly bands along with alarms for the below:

- `HelloWorldLambdaErrorAnomalyDetector` - `HelloWorldLambdaErrorAnomalyAlarm`
- `HelloWorldLambdaInvocationsAnomalyDetector` - `HelloWorldFunctionInvocationAnomalyAlarm`
- `HelloWorldLambda4XXErrorAnomalyDetector` - `HelloWorldLambda4XXAnomalyAlarm`

- Anomaly alarms have the ability to send slack notifications via AlarmActions if a notification ARN is provided.

These alarms can trigger a rollback within the traffic shift of a canary and can successfully trigger a rollback 
- One to note: alarms were tested by manually raising an alarm to create an anomaly 

![Screenshot 2024-03-22 at 14 50 58](https://github.com/govuk-one-login/devplatform-demo-sam-app/assets/117449945/8158958a-9f1f-4ef7-a58f-f5d2f202c9bf)


### Ticket number
[PLAT-3666]
## Checklist

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-3666]: https://govukverify.atlassian.net/browse/PLAT-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ