### PR TITLE
Set container-signer key for demo-sam-app pipeline

### DIFF
--- a/terraform/modules/pipelines/main.tf
+++ b/terraform/modules/pipelines/main.tf
@@ -9,7 +9,7 @@ module "demo-sam-app" {
     IncludePromotion                        = var.include_promotion
     AllowedAccounts                         = var.allowed_accounts
     LogRetentionDays                        = 7
-    ContainerSignerKmsKeyArn                = "none"
+    ContainerSignerKmsKeyArn                = local.container_signer_kms_key_arn
     SigningProfileArn                       = local.signing_profile_arn
     SigningProfileVersionArn                = local.signing_profile_version_arn
     OneLoginRepositoryName                  = var.one_login_repository_name


### PR DESCRIPTION
## Description

Set container-signer key for demo-sam-app pipeline. Needed to fix container signing action for the test images
```
Error: signing [372033887444.dkr.ecr.eu-west-2.amazonaws.com/***:6a03e005afb86d097dbf866a9a0806c5d34e735e]: recursively signing: signing digest: getting fetching default hash function: getting public key: AccessDeniedException: User: arn:aws:sts::372033887444:assumed-role/demo-sam-app-pipeline-GitHubActionsRole-1LHNNU64B0NWN/GitHubActions is not authorized to perform: kms:GetPublicKey on resource: *** because no identity-based policy allows the kms:GetPublicKey action
```
Issue spotted: https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/runs/8846891128/job/24293630540
Fixed in: https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/runs/8846891128/job/24294310265


### Ticket number
[PLAT-568]
## Checklist

- [x] I have tested this and added **links** to **this PR**
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-568]: https://govukverify.atlassian.net/browse/PLAT-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ