### PR TITLE
Switch node-waf app NetworkLBListener port back to 80

### DIFF
--- a/node-with-waf/template.yaml
+++ b/node-with-waf/template.yaml
@@ -553,7 +553,7 @@ Resources:
       LoadBalancerArn:
         Fn::ImportValue:
           !Sub "${VpcStackName}-ApiGatewayVpcLinkTargetNLB"
-      Port: 81
+      Port: 80
       Protocol: TCP
 
   NetworkLoadBalancerTargetGroup:


### PR DESCRIPTION
## Description
The change to port 81 was introduced in https://github.com/govuk-one-login/devplatform-demo-sam-app/pull/427.
Deploying this change to the app in `-stacks-build` caused HTTP 500 errors. Reverting fixed the application. Some more context is [here](https://govukverify.atlassian.net/browse/PLAT-4300?focusedCommentId=142682).

## Checklist

- [x] I have tested this and added output to Jira

- [ ] Automated tests added

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by