### PR TITLE
PLAT-4357 - Use random suffixed terraform state buckets

### DIFF
--- a/terraform/deployments/devplatform-build-demo/site.tf
+++ b/terraform/deployments/devplatform-build-demo/site.tf
@@ -3,7 +3,7 @@ terraform {
 
   # Comment out when bootstrapping
   backend "s3" {
-    bucket         = "devplatform-build-demo-tfstate"
+    bucket         = "devplatform-build-demo-tfstate-0f25031c-03e7-a1f6-3cae-f474fe5f"
     dynamodb_table = "devplatform-build-demo-tfstate-lock-dynamodb"
     key            = "account.tfstate"
     region         = "eu-west-2"
@@ -15,12 +15,13 @@ provider "aws" {
 }
 
 module "state_bucket" {
-  source                       = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
-  bucket_name                  = "devplatform-build-demo-tfstate"
-  logging_bucket               = "devplatform-build-demo-access-logs"
-  enable_tls                   = true
-  enable_state_lock_dynamodb   = true
-  allowed_accounts             = "223594937353,092449966640" # cross-account read access enabled from di-devplatform-staging-demo, di-devplatform-prod-demo
+  source                      = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
+  bucket_name                 = "devplatform-build-demo-tfstate"
+  enable_bucket_random_suffix = true
+  logging_bucket              = "devplatform-build-demo-access-logs"
+  enable_tls                  = true
+  enable_state_lock_dynamodb  = true
+  allowed_accounts            = "223594937353,092449966640" # cross-account read access enabled from di-devplatform-staging-demo, di-devplatform-prod-demo
 }
 
 module "logging_bucket" {

--- a/terraform/deployments/devplatform-prod-demo/site.tf
+++ b/terraform/deployments/devplatform-prod-demo/site.tf
@@ -3,7 +3,7 @@ terraform {
 
   # Comment out when bootstrapping
   backend "s3" {
-    bucket         = "devplatform-prod-demo-tfstate"
+    bucket         = "devplatform-prod-demo-tfstate-be379af5-19d0-d19c-8c02-50bf1aa5f"
     dynamodb_table = "devplatform-prod-demo-tfstate-lock-dynamodb"
     key            = "account.tfstate"
     region         = "eu-west-2"
@@ -15,11 +15,12 @@ provider "aws" {
 }
 
 module "state_bucket" {
-  source                     = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
-  bucket_name                = "devplatform-prod-demo-tfstate"
-  logging_bucket             = "devplatform-prod-demo-access-logs"
-  enable_tls                 = true
-  enable_state_lock_dynamodb = true
+  source                      = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
+  bucket_name                 = "devplatform-prod-demo-tfstate"
+  enable_bucket_random_suffix = true
+  logging_bucket              = "devplatform-prod-demo-access-logs"
+  enable_tls                  = true
+  enable_state_lock_dynamodb  = true
 }
 
 module "logging_bucket" {
@@ -32,7 +33,7 @@ data "terraform_remote_state" "build" {
   backend = "s3"
 
   config = {
-    bucket = "devplatform-build-demo-tfstate"
+    bucket = "devplatform-build-demo-tfstate-0f25031c-03e7-a1f6-3cae-f474fe5f"
     key    = "account.tfstate"
     region = "eu-west-2"
   }
@@ -42,7 +43,7 @@ data "terraform_remote_state" "staging" {
   backend = "s3"
 
   config = {
-    bucket = "devplatform-staging-demo-tfstate"
+    bucket = "devplatform-staging-demo-tfstate-f1e2329f-d773-e63b-deac-425811"
     key    = "account.tfstate"
     region = "eu-west-2"
   }

--- a/terraform/deployments/devplatform-staging-demo/site.tf
+++ b/terraform/deployments/devplatform-staging-demo/site.tf
@@ -3,7 +3,7 @@ terraform {
 
   # Comment out when bootstrapping
   backend "s3" {
-    bucket         = "devplatform-staging-demo-tfstate"
+    bucket         = "devplatform-staging-demo-tfstate-f1e2329f-d773-e63b-deac-425811"
     dynamodb_table = "devplatform-staging-demo-tfstate-lock-dynamodb"
     key            = "account.tfstate"
     region         = "eu-west-2"
@@ -15,12 +15,13 @@ provider "aws" {
 }
 
 module "state_bucket" {
-  source                       = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
-  bucket_name                  = "devplatform-staging-demo-tfstate"
-  logging_bucket               = "devplatform-staging-demo-access-logs"
-  enable_tls                   = true
-  enable_state_lock_dynamodb   = true
-  allowed_accounts             = "092449966640" # cross-account read access enabled only from di-devplatform-prod-demo
+  source                      = "git@github.com:govuk-one-login/ipv-terraform-modules//common/state-bucket-logging-tls?ref=state-bucket-org-access"
+  bucket_name                 = "devplatform-staging-demo-tfstate"
+  enable_bucket_random_suffix = true
+  logging_bucket              = "devplatform-staging-demo-access-logs"
+  enable_tls                  = true
+  enable_state_lock_dynamodb  = true
+  allowed_accounts            = "092449966640" # cross-account read access enabled only from di-devplatform-prod-demo
 }
 
 module "logging_bucket" {
@@ -33,7 +34,7 @@ data "terraform_remote_state" "build" {
   backend = "s3"
 
   config = {
-    bucket = "devplatform-build-demo-tfstate"
+    bucket = "devplatform-build-demo-tfstate-0f25031c-03e7-a1f6-3cae-f474fe5f"
     key    = "account.tfstate"
     region = "eu-west-2"
   }


### PR DESCRIPTION
## Description

In light of recent events: [How an empty S3 bucket can make your AWS bill explode](https://medium.com/@maciej.pocwierz/how-an-empty-s3-bucket-can-make-your-aws-bill-explode-934a383cb8b1) 
https://gds.slack.com/archives/C02U78Y5J3H/p1714490546136239Connect your Slack account 

Randomising the S3 state bucket names to make it more secure
This is dependent on changes made elsewhere https://github.com/govuk-one-login/ipv-terraform-modules/commit/377d20fd779a6b7b87e6251887edcd6d803a2728 (will be separately reviewed in that repo)

### Ticket number
[PLAT-4357]
## Checklist

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by

[PLAT-4357]: https://govukverify.atlassian.net/browse/PLAT-4357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ