### PR TITLE
PSREDP-824: Downgrade upload-action to v3.8.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Description
 
 ### Ticket number
-[PSREDP-XXX]
+[PSREDEV-XXX]
 
 ## Checklist
 - [ ] I have tested this and added output to Jira

--- a/.github/workflows/cloudfront-estimate-dist-post-merge-actions.yml
+++ b/.github/workflows/cloudfront-estimate-dist-post-merge-actions.yml
@@ -46,7 +46,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.CLOUDFRONT_DIST_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/cloudfront-estimate-function-post-merge-actions.yml
+++ b/.github/workflows/cloudfront-estimate-function-post-merge-actions.yml
@@ -47,7 +47,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.CLOUDFRONT_FUNC_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/dev-hosted-zone-post-merge-actions.yml
+++ b/.github/workflows/dev-hosted-zone-post-merge-actions.yml
@@ -47,7 +47,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.DEV_HOSTED_ZONE_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app-deploy-using-environment-secrets.yml
@@ -97,7 +97,7 @@ jobs:
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
             artifact-bucket-name: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -90,7 +90,7 @@ jobs:
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
             artifact-bucket-name: ${{ secrets.SAM_APP_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app2-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app2-deploy-using-environment-secrets.yml
@@ -75,7 +75,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sam-app2-post-merge-actions.yml
+++ b/.github/workflows/sam-app2-post-merge-actions.yml
@@ -56,7 +56,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.SAM_APP2_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/waf-fraud-test-post-merge-actions.yml
+++ b/.github/workflows/waf-fraud-test-post-merge-actions.yml
@@ -45,7 +45,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.WAF_FRAUD_TEST_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_FRAUD_TEST_NAME }}

--- a/.github/workflows/waf-post-merge-actions.yml
+++ b/.github/workflows/waf-post-merge-actions.yml
@@ -46,7 +46,7 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets.WAF_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
## Description

A pre-release upload action release was picked up by dependabot due to the lack of `-beta` tag. Therefore some workflows have been updated with said pre-release tag. 

This PR downgrades all workflows within this repo using the 3.9 release of the upload-action to use v3.8.1

### Ticket number
[PSREDEV-824](https://govukverify.atlassian.net/browse/PSREDEV-824)

## Checklist
- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-824]: https://govukverify.atlassian.net/browse/PSREDEV-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ