### PR TITLE
PSREDEV-1167 - Update node GHAs with upload-action-ecr v1.3.0

### DIFF
--- a/.github/workflows/node-deploy-using-environment-secrets.yml
+++ b/.github/workflows/node-deploy-using-environment-secrets.yml
@@ -46,7 +46,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Build, tag, and push testing image to Amazon ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@PSREDEV-1167
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
@@ -58,7 +58,7 @@ jobs:
           push-latest-tag: true
 
       - name: Build, tag, and push post-deployment testing image to Amazon ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@PSREDEV-1167
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
@@ -70,7 +70,7 @@ jobs:
           push-latest-tag: true
 
       - name: Upload to ECR and tag
-        uses: govuk-one-login/devplatform-upload-action-ecr@PSREDEV-1167
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/node-post-merge-actions.yml
+++ b/.github/workflows/node-post-merge-actions.yml
@@ -12,7 +12,7 @@ defaults:
     working-directory: ./node
 
 jobs:
-  deploy-traffic-test:
+  deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ inputs.environment }}
@@ -27,48 +27,32 @@ jobs:
           role-to-assume: ${{ secrets.NODE_ROLE_TO_ASSUME }}
           aws-region: eu-west-2
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.9.0'
-
       - name: Build, tag, and push testing image to Amazon ECR
-        working-directory: node/tests/traffic-test
-        env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.TRAFFIC_ECR_REPOSITORY }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
+        with:
+          role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          build-and-push-image-only: true
+          working-directory: node/tests/traffic-test
+          artifact-bucket-name: ${{ secrets.NODE_ARTIFACT_BUCKET }}
+          ecr-repo-name: ${{ secrets.TRAFFIC_ECR_REPOSITORY }}
+          checkout-repo: false
+          push-latest-tag: true
 
       - name: Build, tag, and push post-deployment testing image to Amazon ECR
-        working-directory: node/tests/post-deployment-test
-        env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.TEST_ECR_REPOSITORY }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
+        with:
+          role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          build-and-push-image-only: true
+          working-directory: node/tests/post-deployment-test
+          artifact-bucket-name: ${{ secrets.NODE_ARTIFACT_BUCKET }}
+          ecr-repo-name: ${{ secrets.TEST_ECR_REPOSITORY }}
+          checkout-repo: false
+          push-latest-tag: true
 
-  deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      id-token: write
-      contents: read
-    steps:
       - name: Upload to ECR and tag
-        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.6
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.NODE_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
## Description

Update node GHAs with upload-action-ecr v1.3.0. This version supports
- build and push only functionlity for traffic test and post-deployment test images
- maintaining latest tag for mutable ECR repositories i.e. those built with https://github.com/govuk-one-login/devplatform-deploy/tree/main/test-image-repository

### Ticket number
[PSREDEV-1167]

## Checklist
- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-1167]: https://govukverify.atlassian.net/browse/PSREDEV-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ