### PR TITLE
PSREDEV-1227: added ECSLinear10PercentEvery3Minutes DeploymentStrategy

### DIFF
--- a/node/template.yaml
+++ b/node/template.yaml
@@ -27,6 +27,7 @@ Parameters:
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
     AllowedValues:
       - None
+      - CodeDeployDefault.ECSLinear10PercentEvery3Minutes
       - CodeDeployDefault.ECSCanary10Percent5Minutes
       - CodeDeployDefault.ECSCanary10Percent15Minutes
       - CodeDeployDefault.ECSAllAtOnce


### PR DESCRIPTION
## Description
Added an extra DeploymentStrategy, AllowedValue: CodeDeployDefault.ECSLinear10PercentEvery3Minutes. The value is a predefined deployment configuration for an ECS application (as seen [here](https://eu-west-2.console.aws.amazon.com/codesuite/codedeploy/deployment-configs?region=eu-west-2)). 


![Screenshot 2024-07-09 at 18 13 54](https://github.com/govuk-one-login/devplatform-demo-sam-app/assets/117449945/c34cdf36-b442-434d-9d3e-283cc325f901)

### Ticket number
The extra value has been added for support request [[PSREDEV-1227]](https://govukverify.atlassian.net/browse/PSREDEV-1227) 

## Checklist
- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-1227]: https://govukverify.atlassian.net/browse/PSREDEV-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ