### PR TITLE
updated path-to-regexp versions

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -5324,7 +5324,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "6.3.0",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8211,7 +8211,7 @@
         "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/text-encoding": "^0.7.2",
         "just-extend": "^6.2.0",
-        "path-to-regexp": "^6.2.1"
+        "path-to-regexp": "^6.3.0"
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
@@ -8224,9 +8224,9 @@
       }
     },
     "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true
     },
     "node_modules/no-case": {
@@ -8850,9 +8850,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/path-type": {
       "version": "3.0.0",


### PR DESCRIPTION
## Description
Fixed high vulnerability path-to-regexp version to 6.3.0

### Ticket number
[PSREDEV-1804]

## Checklist
- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**
![screenshot_2024-09-13_at_13 33 09_360](https://github.com/user-attachments/assets/a6449170-4cac-4555-82a2-908c96b43c1a)


- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by



[PSREDEV-1804]: https://govukverify.atlassian.net/browse/PSREDEV-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ