### PR TITLE
feat(PSREDEV-2403): make pushing image for demo-sam-app optional

### DIFF
--- a/.github/workflows/sam-app-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app-deploy-using-environment-secrets.yml
@@ -23,6 +23,11 @@ on:
         description: 'Environment to run against'
         type: environment
         required: true
+      upload-tests:
+        description: Set to "false" if you don't require test image to be pushed to ECR
+        type: boolean
+        default: true
+        required: false
 
 defaults:
   run:
@@ -84,6 +89,7 @@ jobs:
           cosign-release: 'v1.9.0'
 
       - name: Build, tag, and push testing image to Amazon ECR
+        if: ${{ inputs.upload-tests == true }}
         env:
           CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
## Description
- When testing pipeline deployments, we may not need/want to deploy an ECR stack
- This makes tests more flexible



### Ticket number
[PSREDEV-2403]



[PSREDEV-2403]: https://govukverify.atlassian.net/browse/PSREDEV-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ