### PR TITLE
LS-3999 Updated Dynatrace Layer

### DIFF
--- a/sam-app2/template.yaml
+++ b/sam-app2/template.yaml
@@ -67,7 +67,7 @@ Mappings:
       dynatraceSecretVersion: c92956bd-f2c4-4dff-b832-63e627657c0c
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables      # pragma: allowlist secret
-      dynatraceSecretVersion: c92956bd-f2c4-4dff-b832-63e627657c0c
+      dynatraceSecretVersion: bf8979d1-f9ea-4823-8aaa-b2d0d82abfdb
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -86,27 +86,27 @@ Globals:
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_CONNECTION_AUTH_TOKEN:
           !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN:${SecretVersion}}}'           # pragma: allowlist secret
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN::${SecretVersion}}}'           # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
               SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
         DT_CONNECTION_BASE_URL:
           !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL:${SecretVersion}}}'             # pragma: allowlist secret
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL::${SecretVersion}}}'             # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
               SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
         DT_CLUSTER_ID:
           !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID:${SecretVersion}}}'                      # pragma: allowlist secret
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID::${SecretVersion}}}'                      # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
               SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
         DT_LOG_COLLECTION_AUTH_TOKEN:
           !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN:${SecretVersion}}}'       # pragma: allowlist secret
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN::${SecretVersion}}}'       # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
               SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
         DT_TENANT:
           !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT:${SecretVersion}}}'                          # pragma: allowlist secret
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT::${SecretVersion}}}'                          # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
               SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
@@ -115,7 +115,7 @@ Globals:
       - arm64
     Layers:
       - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER:${SecretVersion}}}'                             # pragma: allowlist secret
+        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER::${SecretVersion}}}'                             # pragma: allowlist secret
         - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
           SecretVersion: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretVersion ]
 


### PR DESCRIPTION
Testing instructions in PR https://github.com/one-login/observability-infrastructure/pull/56/files

## Description

Adds a SecretVersion to the template to ensure that we're using the right secret for Dynatrace configuration.

The existing layer before this merge is 
<img width="1934" height="800" alt="image" src="https://github.com/user-attachments/assets/d8920f68-d0ec-4f6b-94c4-4b4cbc826354" />
and once this is merged we expect the new layer to be version 1_311 as per the table at the top of the README file in the docs.

### Ticket number
[LS-3999]

### Co-authored by

@chrisdodd93 

[LS-3999]: https://govukverify.atlassian.net/browse/LS-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ