### PR TITLE
fix: update cosign version to v2.5.3 [close circuit breaker]

### DIFF
--- a/.github/workflows/sam-app-deploy-using-environment-secrets.yml
+++ b/.github/workflows/sam-app-deploy-using-environment-secrets.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ inputs.upload-tests == true }}
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.3'
 
       - name: Build, tag, and push testing image to Amazon ECR
         if: ${{ inputs.upload-tests == true }}

--- a/.github/workflows/sam-app-post-merge-actions.yml
+++ b/.github/workflows/sam-app-post-merge-actions.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.3'
 
       - name: Build, tag, and push testing images to Amazon ECR
         env:

--- a/node/README.md
+++ b/node/README.md
@@ -67,6 +67,7 @@ When running [build-tag-push-ecr.sh][3] on MacOS, the `sed` command with -i opti
     sed -i '.bak' "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA|" cf-template.yaml
 ```
 
+
 [1]: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3107258369/How+to+deploy+a+container+to+Fargate+with+secure+pipelines
 [2]: https://github.com/govuk-one-login/devplatform-upload-action-ecr
 [3]: https://github.com/govuk-one-login/devplatform-upload-action-ecr/blob/main/scripts/build-tag-push-ecr.sh


### PR DESCRIPTION
## Description
- cosign v1.9.0 no longer supported
- empty change to node app to trigger deployment

