### PR TITLE
PSREDEV-3350: HelloWorldFunction now inside VPC for step-functions-app

### DIFF
--- a/step-functions-app/template.yaml
+++ b/step-functions-app/template.yaml
@@ -14,6 +14,10 @@ Parameters:
     Description: The ARN of the permissions boundary to apply when creating IAM roles
     Type: String
     Default: None
+  
+  VpcStackName:
+    Description: "The VPC stack name in the account"
+    Type: "String"
 
   Environment:
     Description: The name of the environment to deploy to
@@ -173,6 +177,14 @@ Resources:
       Runtime: java11
       MemorySize: 2048
       ReservedConcurrentExecutions: 5
+      VpcConfig:
+        SecurityGroupIds:
+          - !GetAtt LambdaEgressSecurityGroup.GroupId
+        SubnetIds:
+          - Fn::ImportValue:
+              "Fn::Sub": "${VpcStackName}-ProtectedSubnetIdA"
+          - Fn::ImportValue:
+              "Fn::Sub": "${VpcStackName}-ProtectedSubnetIdB"
       Tags:
         Product: GOV.UK Sign In
         System: Dev Platform
@@ -197,6 +209,20 @@ Resources:
           Value: HelloWorldLogGroup
         - Key: Source
           Value: govuk-one-login/devplatform-demo-sam-app/step-functions-app/template.yaml
+
+  LambdaEgressSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: >-
+        Permits outbound on port 443 from within the VPC to the internet.
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow to the wider internet on port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      VpcId:
+        Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
 
   TriggerLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Description

To address the [lambda-inside-vpc AWS Config rule](https://docs.aws.amazon.com/config/latest/developerguide/lambda-inside-vpc.html). The HelloWorldFunction is now inside a vpc.

<img width="407" height="217" alt="Screenshot 2026-03-19 at 16 26 19" src="https://github.com/user-attachments/assets/71552132-0969-4050-8da2-83feeb1ca338" />

### Ticket number
[PSREDEV-3350]

## Checklist
- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [x] Documentation added ([Link](https://govukverify.atlassian.net/wiki/spaces/devplatform/pages/6341165078/lambda-inside-vpc))
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-3350]: https://govukverify.atlassian.net/browse/PSREDEV-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ