### PR TITLE
PSREDEV-3356: step-functions-app TriggerFunction now inside VPC

### DIFF
--- a/step-functions-app/template.yaml
+++ b/step-functions-app/template.yaml
@@ -143,6 +143,14 @@ Resources:
       AutoPublishAlias: live
       MemorySize: 2048
       ReservedConcurrentExecutions: 5
+      VpcConfig:
+        SecurityGroupIds:
+          - !GetAtt LambdaEgressSecurityGroup.GroupId
+        SubnetIds:
+          - Fn::ImportValue:
+              "Fn::Sub": "${VpcStackName}-PrivateSubnetIdA"
+          - Fn::ImportValue:
+              "Fn::Sub": "${VpcStackName}-PrivateSubnetIdB"
       Events:
         Trigger:
           Type: Api
@@ -374,7 +382,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - "lambda:InvokeFunction"
-                Resource: !GetAtt HelloWorldFunction.Arn
+                Resource:
+                  - !GetAtt HelloWorldFunction.Arn
+                  - !Join [ ":", [ !GetAtt HelloWorldFunction.Arn, "*" ] ]
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
## Description

To address the [lambda-inside-vpc AWS Config rule](https://docs.aws.amazon.com/config/latest/developerguide/lambda-inside-vpc.html). The step-functions-app `TriggerFunction` is now inside a vpc.

<img width="439" height="169" alt="Screenshot 2026-03-26 at 13 21 45" src="https://github.com/user-attachments/assets/18a13a46-1010-485b-b0c5-8ed0b50dad0a" />

### Ticket number
[PSREDEV-3356]

## Checklist
- [x] I have tested this and added output to Jira
**_Comment:_**

- [x] Automated tests added
**_Comment:_**

[PSREDEV-3356]: https://govukverify.atlassian.net/browse/PSREDEV-3356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ