### PR TITLE
BAU: Pinning underscore 1.13.8 due to unlimited recursion security vulnerability

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -62,6 +62,7 @@
     "uglify-js": "3.17.4"
   },
   "overrides": {
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "underscore": "1.13.8"
   }
 }


### PR DESCRIPTION
## Description

underscore dependency is being flagged for - unlimited recursion in _.flatten and _.isEqual, potential for DoS attack - security vulnerability.

https://github.com/govuk-one-login/devplatform-demo-sam-app/security/dependabot/180

Override needed because cfenv not yet patched to higher version of underscore

Tests completing with the node app workflow

<img width="1086" height="107" alt="Screenshot 2026-04-14 at 17 59 11" src="https://github.com/user-attachments/assets/582584bb-1bcf-4d83-a048-a4c502918c35" />

When running from main:
<img width="1021" height="451" alt="Screenshot 2026-04-14 at 17 49 28" src="https://github.com/user-attachments/assets/de5be6da-1971-402f-8f81-2ce3c476b51f" />

When running from the branch with changes:
<img width="1047" height="501" alt="Screenshot 2026-04-14 at 16 20 04" src="https://github.com/user-attachments/assets/42e82ddf-8056-473d-a970-da2dc3ce056b" />

## Checklist
- [x] I have tested this and added output to Jira
**_Comment:_**
